### PR TITLE
ENH: place tract_names instead of index id in output table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,15 @@
 doc/_build/*
+example_data
 htmlcov
+.coverage
+.figleaf
+.ropeproject
 *~
 *pyc
 .*sw?
 *bak
+*.old
+*.orig
 ## The Pycharm internal directory.
 .idea
 build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 numpy>=1.6
 nose>=1.2
-#nibabel>=1.3
--e git://github.com/demianw/nibabel.git@fix_trackvis_scalar_save#egg=nibabel
+nibabel>=2.0
 numpydoc

--- a/scripts/tract_math
+++ b/scripts/tract_math
@@ -35,8 +35,11 @@ def main():
     from tract_querier.tract_math import TractMathWrongArgumentsError
 
     usage = r"""
-    usage: %(prog)s <tract1.vtk> ... <tractN.vtk> operation <operation parameter1> ... <operation parameterN> <output_tract.vtk>
+    usage: %(prog)s <tract1.vtk> ... <tractN.vtk> operation <operation parameter1> ... <operation parameterN> <output_tract.vtk> \
+                      [ optional flags ]
 
+    optional flags:  Always start with "--" and are considered as boolean flags
+        --useFileNamesAsIndex  (when creating table outputs, use input file names instead of index id)
     Available operations:
     """
 
@@ -72,7 +75,8 @@ def main():
         tractography = []
         try:
             for f in args.tractographies:
-                tractography.append(tractography_from_files(f.name))
+                # For each tractography file, pass a tuple of (tractography filename, tractography instance) to tractography list.
+                tractography.append((f.name,tractography_from_files(f.name)))
         except IOError as e:
             print >>sys.stderr, "Error reading file ", f.name, "(%s)" % repr(e)
 
@@ -82,7 +86,7 @@ def main():
         except TractMathWrongArgumentsError, e:
             parser.error('\n\n' + str(e))
         except TypeError:
-            parser.error("\n\nWrong number of parameters for the operation")
+            parser.error("\n\nError: Wrong number of parameters for the operation")
     else:
         parser.error("\n\nOperation not found")
 

--- a/tract_querier/query_processor.py
+++ b/tract_querier/query_processor.py
@@ -16,6 +16,7 @@ keywords = [
     'not',
     'only',
     'endpoints_in',
+    'both_endpoints_in',
     'anterior_of',
     'posterior_of',
     'medial_of',
@@ -339,7 +340,12 @@ class EvaluateQueries(ast.NodeVisitor):
                 #    *tuple((self.tractography_spatial_indexing.crossing_tracts_labels[tract] for tract in tracts))
                 #)
                 return FiberQueryInfo(new_tracts, query_info.labels, query_info.tracts_endpoints)
-
+            elif (node.func.id.lower() == 'both_endpoints_in'):
+                query_info = self.visit(node.args[0])
+                new_tracts = (
+                    query_info.tracts_endpoints[0].intersection(query_info.tracts_endpoints[1])
+                )
+                return FiberQueryInfo(new_tracts, query_info.labels, query_info.tracts_endpoints)
             elif (node.func.id.lower() == 'save' and isinstance(node.args, ast.Str)):
                 self.queries_to_save.add(node.args[0].s)
                 return

--- a/tract_querier/tract_label_indices.py
+++ b/tract_querier/tract_label_indices.py
@@ -131,6 +131,13 @@ def compute_tract_bounding_boxes(tracts, affine_transform=None):
         else:
             ras_coords = tract
 
+        if len(ras_coords) < 2:
+            raise ValueError(
+                'Tracts in the tractography must have at least 2 points'
+                ' tract #%d has less than two points.'
+                ' You can use the tract_math tool to prune short tracts'
+                ' and solve this problem.' % i
+            )
         bounding_boxes[i] = BoundingBox(ras_coords)
 
     box_array = np.empty(

--- a/tract_querier/tract_math/decorator.py
+++ b/tract_querier/tract_math/decorator.py
@@ -28,6 +28,13 @@ def tract_math_operation(help_text, needs_one_tract=True):
 
     def internal_decorator(func):
         def wrapper(*args):
+            # find optional flags and put them at the beginning of args
+            optional_flags = list()
+            while args[-1].startswith("--"):
+              optional_flags.append(args[-1])
+              args=args[:-1]
+            args = (optional_flags,) + args
+
             total_args = len(args)
             argspec = inspect.getargspec(func)
             func_total_args = len(argspec.args)

--- a/tract_querier/tract_math/operations.py
+++ b/tract_querier/tract_math/operations.py
@@ -204,6 +204,24 @@ def tract_dump(tractography):
     return res
 
 
+@tract_math_operation(': Dumps tract endpoints', needs_one_tract=True)
+def tract_dump_endpoints(tractography):
+    res = OrderedDict()
+    tract_number = 'tract #'
+    res[tract_number] = []
+    res['x'] = []
+    res['y'] = []
+    res['z'] = []
+
+    for i, tract in enumerate(tractography.tracts()):
+        res[tract_number] += [i] * 2
+        res['x'] += list(tract[(0, -1), 0])
+        res['y'] += list(tract[(0, -1), 1])
+        res['z'] += list(tract[(0, -1), 2])
+
+    return res
+
+
 @tract_math_operation(': Minimum and maximum distance between two consecutive points')
 def tract_point_distance_min_max(tractography):
     dist_min = numpy.empty(len(tractography.tracts()))

--- a/tract_querier/tract_math/operations.py
+++ b/tract_querier/tract_math/operations.py
@@ -334,7 +334,7 @@ def tract_deform(tractography, image, file_output=None):
         deformation = ndimage.map_coordinates(
             image_, ijk_points.T
         ).squeeze()
-        new_points[:, i] += coord_adjustment[i] * deformation
+        new_points[:, i] -= coord_adjustment[i] * deformation
 
     new_ras_points = new_points  # tract_in_ras(image, new_points)
     start = 0
@@ -357,11 +357,13 @@ def tract_deform(tractography, image, file_output=None):
     'transform is assumed to be in RAS format like Nifti.'
 )
 def tract_affine_transform(
-    tractography, transform_file,
+    tractography, transform_file, ref_image,
     invert=False, file_output=None
 ):
     import nibabel
     import numpy as np
+    ref_image = nibabel.load(ref_image)
+    ref_affine = ref_image.get_affine()
     transform = np.loadtxt(transform_file)
     invert = bool(invert)
     if invert:
@@ -377,9 +379,18 @@ def tract_affine_transform(
         )
         start += len(tract)
 
+    extra_args = {
+        'affine': ref_affine,
+        'image_dims': ref_image.shape
+    }
+
+    #if tractography.extra_args is not None:
+    #    tractography.extra_args.update(extra_args)
+    #    extra_args = tractography.extra_args
+
     return Tractography(
         new_tracts,  tractography.original_tracts_data(),
-        **tractography.extra_args
+        **extra_args
     )
 
 

--- a/tract_querier/tract_math/operations.py
+++ b/tract_querier/tract_math/operations.py
@@ -238,7 +238,8 @@ def tract_subsample(tractography, points_per_tract, file_output):
     tractography.subsample_tracts(int(points_per_tract))
 
     return Tractography(
-        tractography.tracts(),  tractography.tracts_data()
+        tractography.tracts(),  tractography.tracts_data(),
+        **tractography.extra_args
     )
 
 
@@ -265,7 +266,10 @@ def tract_remove_short_tracts(tractography, min_tract_length, file_output):
         else:
             selected_data[key] = item
 
-    return Tractography(selected_tracts, selected_data)
+    return Tractography(
+        selected_tracts, selected_data,
+        **tractography.extra_args
+    )
 
 
 @tract_math_operation('<image> <quantity_name> <tractography_file_output>: maps the values of an image to the tract points')
@@ -303,7 +307,8 @@ def tract_map_image(tractography, image, quantity_name, file_output):
         tractography.original_tracts_data()[quantity_name] = new_scalar_data
 
         return Tractography(
-            tractography.original_tracts(),  tractography.original_tracts_data()
+            tractography.original_tracts(),  tractography.original_tracts_data(),
+            **tractography.extra_args
         )
 
 
@@ -367,8 +372,18 @@ def tract_merge(tractographies, file_output):
     all_data = {}
     keys = [set(t.tracts_data().keys()) for t in tractographies]
     common_keys = keys[0].intersection(*keys[1:])
+
+    affine = tractographies[0].extra_args.get('affine', None)
+    image_dims = tractographies[0].extra_args.get('image_dims', None)
+
     for tract in tractographies:
         tracts = tract.tracts()
+        if affine is not None and 'affine' in tract.extra_args:
+            if (tract.affine != affine).any():
+                affine = None
+        if image_dims is not None and 'image_dims' in tract.extra_args:
+            if (tract.image_dims != image_dims).any():
+                image_dims = None
         all_tracts += tract.tracts()
         data = tract.tracts_data()
         for k in common_keys:
@@ -379,7 +394,10 @@ def tract_merge(tractographies, file_output):
             else:
                 all_data[k] = data[k]
 
-    return Tractography(all_tracts, all_data)
+    return Tractography(
+        all_tracts, all_data,
+        affine=affine, image_dims=image_dims
+    )
 
 
 @tract_math_operation('<volume unit> <tract1.vtk> ... <tractN.vtk>: calculates the kappa value of the first tract with the rest in the space of the reference image')
@@ -551,7 +569,8 @@ def tract_smooth(tractography, var, file_output):
 
     return Tractography(
         tractography.original_tracts(),
-        tractography.original_tracts_data()
+        tractography.original_tracts_data(),
+        **tractography.extra_args
     )
 
 

--- a/tract_querier/tractography/trackvis.py
+++ b/tract_querier/tractography/trackvis.py
@@ -19,7 +19,7 @@ def tractography_to_trackvis_file(filename, tractography, affine=None, image_dim
         raise ValueError("Affine transform has to be provided")
 
     trackvis.aff_to_hdr(affine, trk_header, True, True)
-
+    trk_header['origin'] = 0.
     if image_dimensions is not None:
         trk_header['dim'] = image_dimensions
     elif hasattr(tractography, 'image_dimensions'):

--- a/tract_querier/tractography/trackvis.py
+++ b/tract_querier/tractography/trackvis.py
@@ -100,8 +100,9 @@ def tractography_from_trackvis_file(filename):
     affine = header['vox_to_ras']
     image_dims = header['dim']
 
-    tr = Tractography(tracts, tracts_data)
-    tr.affine = affine
-    tr.image_dims = image_dims
+    tr = Tractography(
+        tracts, tracts_data,
+        affine=affine, image_dims=image_dims
+    )
 
     return tr

--- a/tract_querier/tractography/tractography.py
+++ b/tract_querier/tractography/tractography.py
@@ -21,7 +21,7 @@ class Tractography:
         Check that tracts and tracts_data are valid
     """
 
-    def __init__(self, tracts=None, tracts_data=None, validate=True):
+    def __init__(self, tracts=None, tracts_data=None, validate=True, **kwargs):
         if tracts is not None and tracts_data is None:
             tracts_data = {}
         self._tracts = []
@@ -31,8 +31,21 @@ class Tractography:
         self._subsampled_tracts = None
         self._subsampled_data = None
 
+        self._extra_args = []
+        for k, v in kwargs.items():
+            if k[0] != '_':
+                setattr(self, k, v)
+                self._extra_args.append(k)
+
         if tracts is not None:
             self.append(tracts, tracts_data, validate=validate)
+
+    @property
+    def extra_args(self):
+        ret = {}
+        for k in self._extra_args:
+            ret[k] = getattr(self, k)
+        return ret
 
     def append(self, tracts, tracts_data=None, validate=True):
         r"""


### PR DESCRIPTION
This patch provide possibility to add optional flags to tract_math.
    Optional flags are always start with "--" and are considered as boolean
    flags.
    A newly added optional flag is "--useFileNamesAsIndex".
    When this flag is used, the created output table uses tractography file
    names instead of index IDs.

PS: I did not have access to push to BRAINSia/tract_querier; therefore, I created a new fork "aghayoor/tract_querier" and requested a pull request to BRAINSia/tract_querier.
